### PR TITLE
Add `PATCH` and `CONNECT` to the `HTTPMethod` enum

### DIFF
--- a/httpx_retries/retry.py
+++ b/httpx_retries/retry.py
@@ -26,6 +26,8 @@ else:  # pragma: no cover
         DELETE = "DELETE"
         OPTIONS = "OPTIONS"
         TRACE = "TRACE"
+        PATCH = "PATCH"
+        CONNECT = "CONNECT"
 
 
 class Retry:


### PR DESCRIPTION
When using this library in Python 3.9 and making a `PATCH` request, it fails with the following error:
```
ValueError: 'PATCH' is not a valid HTTPMethod
```
which originates in
https://github.com/will-ockmore/httpx-retries/blob/261cd0428539e87824d6366adc349de85da2cc68/httpx_retries/retry.py#L117-L119

This happens because the `HTTPMethod` class doesn't recognise [all 9 HTTP methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods).

P.S.
Thanks for writing this library! Well written and super useful :)