### PR TITLE
Accept transport instances that extend from httpx base transport classes

### DIFF
--- a/httpx_retries/transport.py
+++ b/httpx_retries/transport.py
@@ -46,14 +46,14 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
 
     def __init__(
         self,
-        transport: Optional[Union[httpx.HTTPTransport, httpx.AsyncHTTPTransport]] = None,
+        transport: Optional[Union[httpx.BaseTransport, httpx.AsyncBaseTransport]] = None,
         retry: Optional[Retry] = None,
     ) -> None:
         self.retry = retry or Retry()
 
         if transport is not None:
-            self._sync_transport = transport if isinstance(transport, httpx.HTTPTransport) else None
-            self._async_transport = transport if isinstance(transport, httpx.AsyncHTTPTransport) else None
+            self._sync_transport = transport if isinstance(transport, httpx.BaseTransport) else None
+            self._async_transport = transport if isinstance(transport, httpx.AsyncBaseTransport) else None
         else:
             self._sync_transport = httpx.HTTPTransport()
             self._async_transport = httpx.AsyncHTTPTransport()

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -77,12 +77,12 @@ def mock_async_responses(mock_asleep: AsyncMock) -> Generator[AsyncMockResponse,
         yield mock_asleep, status_code_sequences
 
 
-class MockHTTPTransport(httpx.HTTPTransport):
+class MockHTTPTransport(httpx.BaseTransport):
     def handle_request(self, request: Request) -> Response:
         return create_response(request, 200)
 
 
-class MockAsyncHTTPTransport(httpx.AsyncHTTPTransport):
+class MockAsyncHTTPTransport(httpx.AsyncBaseTransport):
     async def handle_async_request(self, request: Request) -> Response:
         return create_response(request, 200)
 


### PR DESCRIPTION
Closes #18 

Loosen the restriction on `transport` when initializing `RetryTransport`, so that downstream transports can extend from `httpx.BaseTransport` and `httpx.AsyncBaseTransport`.

Tested by changing `MockHTTPTransport` and `MockAsyncHTTPTransport` to extend from the respective base transport classes.