### PR TITLE
Relax version constraint for httpx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.4.0"
 description = "A retry layer for HTTPX."
 requires-python = ">=3.9"
 authors = [{ name = "Will Ockmore", email = "will.ockmore@gmail.com" }]
-dependencies = ["httpx>=0.27.0"]
+dependencies = ["httpx>=0.20.0"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/uv.lock
+++ b/uv.lock
@@ -320,7 +320,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "httpx", specifier = ">=0.27.0" }]
+requires-dist = [{ name = "httpx", specifier = ">=0.20.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
From version `0.20.0` onwards, httpx exposes consistent method signatures and a full set of expected exceptions, so we can relax the existing version constraint to accomodate earlier versions.

closes #27 