### PR TITLE
Handle non-standard status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2025-09-02
+
+### Fixed
+- Allow non-standard status codes to be passed to the `status_forcelist` parameter for `Retry`, and handled
+in `Retry.is_retryable_status_code`.
+
 ## [0.4.1] - 2025-08-23
 
 ### Added

--- a/httpx_retries/retry.py
+++ b/httpx_retries/retry.py
@@ -109,9 +109,7 @@ class Retry:
         self.allowed_methods = frozenset(
             HTTPMethod(method.upper()) for method in (allowed_methods or self.RETRYABLE_METHODS)
         )
-        self.status_forcelist = frozenset(
-            HTTPStatus(int(code)) for code in (status_forcelist or self.RETRYABLE_STATUS_CODES)
-        )
+        self.status_forcelist = frozenset((status_forcelist or self.RETRYABLE_STATUS_CODES))
         self.retryable_exceptions = (
             self.RETRYABLE_EXCEPTIONS if retry_on_exceptions is None else tuple(retry_on_exceptions)
         )
@@ -122,7 +120,7 @@ class Retry:
 
     def is_retryable_status_code(self, status_code: int) -> bool:
         """Check if a status code is retryable."""
-        return HTTPStatus(status_code) in self.status_forcelist
+        return status_code in self.status_forcelist
 
     def is_retryable_exception(self, exception: httpx.HTTPError) -> bool:
         """Check if an exception is retryable."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "httpx-retries"
-version = "0.4.1"
+version = "0.4.2"
 description = "A retry layer for HTTPX."
 requires-python = ">=3.9"
 authors = [{ name = "Will Ockmore", email = "will.ockmore@gmail.com" }]

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -80,6 +80,14 @@ def test_custom_retry_status_codes_enum() -> None:
     assert retry.is_retryable_status_code(502) is False
 
 
+def test_custom_retry_status_codes_non_standard() -> None:
+    retry = Retry(status_forcelist=[523, 599])
+    assert retry.is_retryable_status_code(523) is True
+    assert retry.is_retryable_status_code(599) is True
+    assert retry.is_retryable_status_code(500) is False
+    assert retry.is_retryable_status_code(502) is False
+
+
 def test_is_exhausted() -> None:
     retry = Retry(total=3)
     assert retry.is_exhausted() is False

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "httpx-retries"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Allow non-standard status codes to be passed to the `status_forcelist` parameter for `Retry`, and handled
in `Retry.is_retryable_status_code`.

Closes #34 

