### PR TITLE
Close transports

### DIFF
--- a/httpx_retries/transport.py
+++ b/httpx_retries/transport.py
@@ -58,6 +58,20 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
             self._sync_transport = httpx.HTTPTransport()
             self._async_transport = httpx.AsyncHTTPTransport()
 
+    def close(self) -> None:
+        """
+        Closes this transport.
+        """
+        if self._sync_transport is not None:
+            self._sync_transport.close()
+
+    async def aclose(self) -> None:
+        """
+        Closes this transport.
+        """
+        if self._async_transport is not None:
+            await self._async_transport.aclose()
+
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         """
         Sends an HTTP request, possibly with retries.


### PR DESCRIPTION
This fix implements `RetryTransport.close()` and `.aclose()` so the inner transports are freed when `httpx.Client.close()` or `httpx.Client.aclose()` is called.  This avoids resource warnings about leaked SSL sockets when Python exits, e.g.:

```
ResourceWarning: unclosed <ssl.SSLSocket fd=11, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('192.168.1.6', 40038), raddr=('18.245.162.93', 443)>
```

Decisions:
 -  I wasn't sure whether to close transport passed as arguments to `RetryTransport.__init__`, so I implemented the same behavior as `httpx.Client.close()`, which is to close *all* transports irrespective of where they came from.
 -  `RetryTransport.__init__` creates both sync and async transports if you don't pass one in, but `RetryTransport.close()` and `.aclose()` only close their own transport. I don't think this would cause problems since the one you close is likely the one you use, so the transport you don't close *probably* didn't ever open any sockets.