### PR TITLE
Simplify `Retry` subclassing

### DIFF
--- a/httpx_retries/retry.py
+++ b/httpx_retries/retry.py
@@ -243,7 +243,7 @@ class Retry:
     def increment(self) -> "Retry":
         """Return a new Retry instance with the attempt count incremented."""
         logger.debug("increment retry=%s new_attempts_made=%s", self, self.attempts_made + 1)
-        return Retry(
+        return self.__class__(
             total=self.total,
             max_backoff_wait=self.max_backoff_wait,
             backoff_factor=self.backoff_factor,


### PR DESCRIPTION
Just submitting a code change that would resolve #41! 

In short, this would allow easier subclassing of the Retry class, because `increment()` doesn't also need to be overridden.
