### PR TITLE
fix: redact query strings from DEBUG log lines

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -88,12 +88,7 @@ DEBUG [2025-08-23 09:34:27] httpcore.http11 - response_closed.complete
 
 ## Security Note
 
-> **Warning:** DEBUG logging includes full request URLs, including query strings.
-> If your application passes secrets in query strings (API keys, signed URL tokens, etc.),
-> those values will appear in your log output.
->
-> Redact sensitive data at the logging-handler level before enabling DEBUG logging,
-> or use a logger filter to strip query parameters.
->
-> The retry layer multiplies log lines per request (one per attempt), which increases
-> the exposure surface compared to a single request.
+!!! warning
+    DEBUG logging includes full request URLs, including query strings. If your application passes secrets in query strings (API keys, signed URL tokens, etc.), those values will appear in your log output.
+
+Redact sensitive data at the logging-handler level before enabling DEBUG logging, or use a logger filter to strip query parameters.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -85,3 +85,15 @@ DEBUG [2025-08-23 09:34:27] httpcore.http11 - receive_response_body.complete
 DEBUG [2025-08-23 09:34:27] httpcore.http11 - response_closed.started
 DEBUG [2025-08-23 09:34:27] httpcore.http11 - response_closed.complete
 ```
+
+## Security Note
+
+> **Warning:** DEBUG logging includes full request URLs, including query strings.
+> If your application passes secrets in query strings (API keys, signed URL tokens, etc.),
+> those values will appear in your log output.
+>
+> Redact sensitive data at the logging-handler level before enabling DEBUG logging,
+> or use a logger filter to strip query parameters.
+>
+> The retry layer multiplies log lines per request (one per attempt), which increases
+> the exposure surface compared to a single request.

--- a/httpx_retries/transport.py
+++ b/httpx_retries/transport.py
@@ -46,20 +46,14 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
 
     def __init__(
         self,
-        transport: Optional[
-            Union[httpx.BaseTransport, httpx.AsyncBaseTransport]
-        ] = None,
+        transport: Optional[Union[httpx.BaseTransport, httpx.AsyncBaseTransport]] = None,
         retry: Optional[Retry] = None,
     ) -> None:
         self.retry = retry or Retry()
 
         if transport is not None:
-            self._sync_transport = (
-                transport if isinstance(transport, httpx.BaseTransport) else None
-            )
-            self._async_transport = (
-                transport if isinstance(transport, httpx.AsyncBaseTransport) else None
-            )
+            self._sync_transport = transport if isinstance(transport, httpx.BaseTransport) else None
+            self._async_transport = transport if isinstance(transport, httpx.AsyncBaseTransport) else None
         else:
             self._sync_transport = httpx.HTTPTransport()
             self._async_transport = httpx.AsyncHTTPTransport()
@@ -89,9 +83,7 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
             The final response.
         """
         if self._sync_transport is None:
-            raise RuntimeError(
-                "Synchronous request received but no sync transport available"
-            )
+            raise RuntimeError("Synchronous request received but no sync transport available")
 
         logger.debug(
             "handle_request started %s %s%s",
@@ -126,9 +118,7 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
             The final response.
         """
         if self._async_transport is None:
-            raise RuntimeError(
-                "Async request received but no async transport available"
-            )
+            raise RuntimeError("Async request received but no async transport available")
 
         logger.debug(
             "handle_async_request started %s %s%s",
@@ -185,9 +175,7 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
                 response = e
                 continue
 
-            if retry.is_exhausted() or not retry.is_retryable_status_code(
-                response.status_code
-            ):
+            if retry.is_exhausted() or not retry.is_retryable_status_code(response.status_code):
                 return response
 
     async def _retry_operation_async(
@@ -222,7 +210,5 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
                 response = e
                 continue
 
-            if retry.is_exhausted() or not retry.is_retryable_status_code(
-                response.status_code
-            ):
+            if retry.is_exhausted() or not retry.is_retryable_status_code(response.status_code):
                 return response

--- a/httpx_retries/transport.py
+++ b/httpx_retries/transport.py
@@ -46,14 +46,20 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
 
     def __init__(
         self,
-        transport: Optional[Union[httpx.BaseTransport, httpx.AsyncBaseTransport]] = None,
+        transport: Optional[
+            Union[httpx.BaseTransport, httpx.AsyncBaseTransport]
+        ] = None,
         retry: Optional[Retry] = None,
     ) -> None:
         self.retry = retry or Retry()
 
         if transport is not None:
-            self._sync_transport = transport if isinstance(transport, httpx.BaseTransport) else None
-            self._async_transport = transport if isinstance(transport, httpx.AsyncBaseTransport) else None
+            self._sync_transport = (
+                transport if isinstance(transport, httpx.BaseTransport) else None
+            )
+            self._async_transport = (
+                transport if isinstance(transport, httpx.AsyncBaseTransport) else None
+            )
         else:
             self._sync_transport = httpx.HTTPTransport()
             self._async_transport = httpx.AsyncHTTPTransport()
@@ -83,9 +89,16 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
             The final response.
         """
         if self._sync_transport is None:
-            raise RuntimeError("Synchronous request received but no sync transport available")
+            raise RuntimeError(
+                "Synchronous request received but no sync transport available"
+            )
 
-        logger.debug("handle_request started %s %s%s", request.method, request.url.host, request.url.path)
+        logger.debug(
+            "handle_request started %s %s%s",
+            request.method,
+            request.url.host,
+            request.url.path,
+        )
 
         if self.retry.is_retryable_method(request.method):
             send_method = partial(self._sync_transport.handle_request)
@@ -95,7 +108,10 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
 
         logger.debug(
             "handle_request finished %s %s%s response=%s",
-            request.method, request.url.host, request.url.path, response
+            request.method,
+            request.url.host,
+            request.url.path,
+            response,
         )
 
         return response
@@ -110,9 +126,16 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
             The final response.
         """
         if self._async_transport is None:
-            raise RuntimeError("Async request received but no async transport available")
+            raise RuntimeError(
+                "Async request received but no async transport available"
+            )
 
-        logger.debug("handle_async_request started %s %s%s", request.method, request.url.host, request.url.path)
+        logger.debug(
+            "handle_async_request started %s %s%s",
+            request.method,
+            request.url.host,
+            request.url.path,
+        )
 
         if self.retry.is_retryable_method(request.method):
             send_method = partial(self._async_transport.handle_async_request)
@@ -122,7 +145,10 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
 
         logger.debug(
             "handle_async_request finished %s %s%s response=%s",
-            request.method, request.url.host, request.url.path, response
+            request.method,
+            request.url.host,
+            request.url.path,
+            response,
         )
 
         return response
@@ -141,9 +167,13 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
                     response.close()
 
                 logger.debug(
-                "_retry_operation retrying %s %s%s response=%s retry=%s",
-                request.method, request.url.host, request.url.path, response, retry
-            )
+                    "_retry_operation retrying %s %s%s response=%s retry=%s",
+                    request.method,
+                    request.url.host,
+                    request.url.path,
+                    response,
+                    retry,
+                )
                 retry = retry.increment()
                 retry.sleep(response)
             try:
@@ -155,7 +185,9 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
                 response = e
                 continue
 
-            if retry.is_exhausted() or not retry.is_retryable_status_code(response.status_code):
+            if retry.is_exhausted() or not retry.is_retryable_status_code(
+                response.status_code
+            ):
                 return response
 
     async def _retry_operation_async(
@@ -173,7 +205,11 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
 
                 logger.debug(
                     "_retry_operation_async retrying %s %s%s response=%s retry=%s",
-                    request.method, request.url.host, request.url.path, response, retry
+                    request.method,
+                    request.url.host,
+                    request.url.path,
+                    response,
+                    retry,
                 )
                 retry = retry.increment()
                 await retry.asleep(response)
@@ -186,5 +222,7 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
                 response = e
                 continue
 
-            if retry.is_exhausted() or not retry.is_retryable_status_code(response.status_code):
+            if retry.is_exhausted() or not retry.is_retryable_status_code(
+                response.status_code
+            ):
                 return response

--- a/httpx_retries/transport.py
+++ b/httpx_retries/transport.py
@@ -85,12 +85,7 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
         if self._sync_transport is None:
             raise RuntimeError("Synchronous request received but no sync transport available")
 
-        logger.debug(
-            "handle_request started %s %s%s",
-            request.method,
-            request.url.host,
-            request.url.path,
-        )
+        logger.debug("handle_request started request=%s", request)
 
         if self.retry.is_retryable_method(request.method):
             send_method = partial(self._sync_transport.handle_request)
@@ -98,13 +93,7 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
         else:
             response = self._sync_transport.handle_request(request)
 
-        logger.debug(
-            "handle_request finished %s %s%s response=%s",
-            request.method,
-            request.url.host,
-            request.url.path,
-            response,
-        )
+        logger.debug("handle_request finished request=%s response=%s", request, response)
 
         return response
 
@@ -120,12 +109,7 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
         if self._async_transport is None:
             raise RuntimeError("Async request received but no async transport available")
 
-        logger.debug(
-            "handle_async_request started %s %s%s",
-            request.method,
-            request.url.host,
-            request.url.path,
-        )
+        logger.debug("handle_async_request started request=%s", request)
 
         if self.retry.is_retryable_method(request.method):
             send_method = partial(self._async_transport.handle_async_request)
@@ -133,13 +117,7 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
         else:
             response = await self._async_transport.handle_async_request(request)
 
-        logger.debug(
-            "handle_async_request finished %s %s%s response=%s",
-            request.method,
-            request.url.host,
-            request.url.path,
-            response,
-        )
+        logger.debug("handle_async_request finished request=%s response=%s", request, response)
 
         return response
 
@@ -156,14 +134,7 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
                 if isinstance(response, httpx.Response):
                     response.close()
 
-                logger.debug(
-                    "_retry_operation retrying %s %s%s response=%s retry=%s",
-                    request.method,
-                    request.url.host,
-                    request.url.path,
-                    response,
-                    retry,
-                )
+                logger.debug("_retry_operation retrying request=%s response=%s retry=%s", request, response, retry)
                 retry = retry.increment()
                 retry.sleep(response)
             try:
@@ -192,12 +163,7 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
                     await response.aclose()
 
                 logger.debug(
-                    "_retry_operation_async retrying %s %s%s response=%s retry=%s",
-                    request.method,
-                    request.url.host,
-                    request.url.path,
-                    response,
-                    retry,
+                    "_retry_operation_async retrying request=%s response=%s retry=%s", request, response, retry
                 )
                 retry = retry.increment()
                 await retry.asleep(response)

--- a/httpx_retries/transport.py
+++ b/httpx_retries/transport.py
@@ -85,7 +85,7 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
         if self._sync_transport is None:
             raise RuntimeError("Synchronous request received but no sync transport available")
 
-        logger.debug("handle_request started request=%s", request)
+        logger.debug("handle_request started %s %s%s", request.method, request.url.host, request.url.path)
 
         if self.retry.is_retryable_method(request.method):
             send_method = partial(self._sync_transport.handle_request)
@@ -93,7 +93,7 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
         else:
             response = self._sync_transport.handle_request(request)
 
-        logger.debug("handle_request finished request=%s response=%s", request, response)
+        logger.debug("handle_request finished %s %s%s response=%s", request.method, request.url.host, request.url.path, response)
 
         return response
 
@@ -109,7 +109,7 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
         if self._async_transport is None:
             raise RuntimeError("Async request received but no async transport available")
 
-        logger.debug("handle_async_request started request=%s", request)
+        logger.debug("handle_async_request started %s %s%s", request.method, request.url.host, request.url.path)
 
         if self.retry.is_retryable_method(request.method):
             send_method = partial(self._async_transport.handle_async_request)
@@ -117,7 +117,7 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
         else:
             response = await self._async_transport.handle_async_request(request)
 
-        logger.debug("handle_async_request finished request=%s response=%s", request, response)
+        logger.debug("handle_async_request finished %s %s%s response=%s", request.method, request.url.host, request.url.path, response)
 
         return response
 
@@ -134,7 +134,7 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
                 if isinstance(response, httpx.Response):
                     response.close()
 
-                logger.debug("_retry_operation retrying request=%s response=%s retry=%s", request, response, retry)
+                logger.debug("_retry_operation retrying %s %s%s response=%s retry=%s", request.method, request.url.host, request.url.path, response, retry)
                 retry = retry.increment()
                 retry.sleep(response)
             try:
@@ -163,7 +163,7 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
                     await response.aclose()
 
                 logger.debug(
-                    "_retry_operation_async retrying request=%s response=%s retry=%s", request, response, retry
+                    "_retry_operation_async retrying %s %s%s response=%s retry=%s", request.method, request.url.host, request.url.path, response, retry
                 )
                 retry = retry.increment()
                 await retry.asleep(response)

--- a/httpx_retries/transport.py
+++ b/httpx_retries/transport.py
@@ -93,7 +93,10 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
         else:
             response = self._sync_transport.handle_request(request)
 
-        logger.debug("handle_request finished %s %s%s response=%s", request.method, request.url.host, request.url.path, response)
+        logger.debug(
+            "handle_request finished %s %s%s response=%s",
+            request.method, request.url.host, request.url.path, response
+        )
 
         return response
 
@@ -117,7 +120,10 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
         else:
             response = await self._async_transport.handle_async_request(request)
 
-        logger.debug("handle_async_request finished %s %s%s response=%s", request.method, request.url.host, request.url.path, response)
+        logger.debug(
+            "handle_async_request finished %s %s%s response=%s",
+            request.method, request.url.host, request.url.path, response
+        )
 
         return response
 
@@ -134,7 +140,10 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
                 if isinstance(response, httpx.Response):
                     response.close()
 
-                logger.debug("_retry_operation retrying %s %s%s response=%s retry=%s", request.method, request.url.host, request.url.path, response, retry)
+                logger.debug(
+                "_retry_operation retrying %s %s%s response=%s retry=%s",
+                request.method, request.url.host, request.url.path, response, retry
+            )
                 retry = retry.increment()
                 retry.sleep(response)
             try:
@@ -163,7 +172,8 @@ class RetryTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
                     await response.aclose()
 
                 logger.debug(
-                    "_retry_operation_async retrying %s %s%s response=%s retry=%s", request.method, request.url.host, request.url.path, response, retry
+                    "_retry_operation_async retrying %s %s%s response=%s retry=%s",
+                    request.method, request.url.host, request.url.path, response, retry
                 )
                 retry = retry.increment()
                 await retry.asleep(response)


### PR DESCRIPTION
Fixes #60
Updated all 6 DEBUG log lines in transport.py to log only request.method, request.url.host, and request.url.path, omitting query strings to prevent credential leakage.
Added a Security Note section to docs/logging.md warning users about query string exposure when DEBUG logging is enabled.