### PR TITLE
Security fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,8 @@ permissions:
 on:
   push:
     tags:
-      - "*"
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+[a-z]*[0-9]*"
 
 jobs:
   publish:
@@ -19,13 +20,13 @@ jobs:
       name: release
 
     steps:
-      - uses: "actions/checkout@v4"
-      - uses: "actions/setup-python@v5"
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: 3.9
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           python-version: 3.9
           version: "0.5.24"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -17,14 +17,14 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: "actions/checkout@v4"
-      - uses: "actions/setup-python@v5"
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "${{ matrix.python-version }}"
           allow-prereleases: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           python-version: "${{ matrix.python-version }}"
           version: "0.5.24"

--- a/docs/behaviour.md
+++ b/docs/behaviour.md
@@ -69,6 +69,19 @@ To enable this strategy, just set the **backoff_factor** parameter for [Retry][h
 
     Take some time to read the parameters to [Retry][httpx_retries.Retry], to see what's available to tweak; for example, you can change the amount of `jitter` applied.
 
+## Bounding the total wait time
+
+`max_backoff_wait` caps a *single* sleep between attempts; it does **not** cap the cumulative sleep across a request. With the defaults (`total=10`, `max_backoff_wait=120`) and `respect_retry_after_header=True`, a server can return `Retry-After: 120` repeatedly and hold the client for up to `total * max_backoff_wait` (~20 minutes) before the request resolves.
+
+To bound the total time spent sleeping across all retry attempts for a request, set `total_timeout`:
+
+```python
+retry = Retry(total=10, total_timeout=30)
+```
+
+- Each sleep is capped by the remaining budget (`total_timeout - elapsed_sleep`).
+- Once the budget is exhausted, the retry loop short-circuits and returns the last response (or raises the last exception).
+
 ## Configuring a custom strategy
 
 If you want to implement your own retry strategy, you can subclass [Retry][httpx_retries.Retry] and override the [backoff_strategy][httpx_retries.Retry.backoff_strategy] method.

--- a/httpx_retries/retry.py
+++ b/httpx_retries/retry.py
@@ -56,10 +56,23 @@ class Retry:
         backoff_jitter (float, optional): The amount of jitter to add to the backoff time, between 0 and 1.
             Defaults to 1 (full jitter).
         attempts_made (int, optional): The number of retry attempts already made.
+        total_timeout (float, optional): The maximum cumulative time in seconds to spend sleeping between retry
+            attempts across a single request. Unlike `max_backoff_wait` (which caps a single sleep), this caps the
+            sum of all sleeps. Useful as a defence against a server that returns a large `Retry-After`
+            repeatedly. Defaults to None (no cumulative cap).
+        elapsed_sleep (float, optional): Cumulative sleep time already spent on this request. Preserved across
+            `increment()` calls; users typically do not set this directly.
     """
 
     RETRYABLE_METHODS: Final[frozenset[HTTPMethod]] = frozenset(
-        [HTTPMethod.HEAD, HTTPMethod.GET, HTTPMethod.PUT, HTTPMethod.DELETE, HTTPMethod.OPTIONS, HTTPMethod.TRACE]
+        [
+            HTTPMethod.HEAD,
+            HTTPMethod.GET,
+            HTTPMethod.PUT,
+            HTTPMethod.DELETE,
+            HTTPMethod.OPTIONS,
+            HTTPMethod.TRACE,
+        ]
     )
     RETRYABLE_STATUS_CODES: Final[frozenset[HTTPStatus]] = frozenset(
         [
@@ -86,6 +99,8 @@ class Retry:
         max_backoff_wait: float = 120.0,
         backoff_jitter: float = 1.0,
         attempts_made: int = 0,
+        total_timeout: Optional[float] = None,
+        elapsed_sleep: float = 0.0,
     ) -> None:
         """Initialize a new Retry instance."""
         if total < 0:
@@ -98,6 +113,10 @@ class Retry:
             raise ValueError("backoff_jitter must be between 0 and 1")
         if attempts_made < 0:
             raise ValueError("attempts_made must be non-negative")
+        if total_timeout is not None and total_timeout <= 0:
+            raise ValueError("total_timeout must be positive")
+        if elapsed_sleep < 0:
+            raise ValueError("elapsed_sleep must be non-negative")
 
         self.total = total
         self.backoff_factor = backoff_factor
@@ -105,13 +124,19 @@ class Retry:
         self.max_backoff_wait = max_backoff_wait
         self.backoff_jitter = backoff_jitter
         self.attempts_made = attempts_made
+        self.total_timeout = total_timeout
+        self.elapsed_sleep = elapsed_sleep
 
         self.allowed_methods: frozenset[str] = frozenset(
             method.upper() for method in (allowed_methods or self.RETRYABLE_METHODS)
         )
-        self.status_forcelist = frozenset((status_forcelist or self.RETRYABLE_STATUS_CODES))
+        self.status_forcelist = frozenset(
+            (status_forcelist or self.RETRYABLE_STATUS_CODES)
+        )
         self.retryable_exceptions = (
-            self.RETRYABLE_EXCEPTIONS if retry_on_exceptions is None else tuple(retry_on_exceptions)
+            self.RETRYABLE_EXCEPTIONS
+            if retry_on_exceptions is None
+            else tuple(retry_on_exceptions)
         )
 
     def is_retryable_method(self, method: str) -> bool:
@@ -141,7 +166,11 @@ class Retry:
 
     def is_exhausted(self) -> bool:
         """Check if the retry attempts have been exhausted."""
-        return self.attempts_made >= self.total
+        if self.attempts_made >= self.total:
+            return True
+        if self.total_timeout is not None and self.elapsed_sleep >= self.total_timeout:
+            return True
+        return False
 
     def parse_retry_after(self, retry_after: str) -> float:
         """
@@ -165,7 +194,9 @@ class Retry:
             if parsed_date.tzinfo is None:
                 parsed_date = parsed_date.replace(tzinfo=datetime.timezone.utc)
 
-            diff = (parsed_date - datetime.datetime.now(datetime.timezone.utc)).total_seconds()
+            diff = (
+                parsed_date - datetime.datetime.now(datetime.timezone.utc)
+            ).total_seconds()
             return max(0.0, diff)
         except (TypeError, ValueError):
             raise ValueError(f"Invalid Retry-After header: {retry_after}")
@@ -200,21 +231,36 @@ class Retry:
 
         return min(backoff, self.max_backoff_wait)
 
-    def _calculate_sleep(self, headers: Union[httpx.Headers, Mapping[str, str]]) -> float:
+    def _calculate_sleep(
+        self, headers: Union[httpx.Headers, Mapping[str, str]]
+    ) -> float:
         """Calculate the sleep duration based on headers and backoff strategy."""
+        sleep_time = 0.0
         # Check Retry-After header first if enabled
         if self.respect_retry_after_header:
             retry_after = headers.get("Retry-After", "").strip()
             if retry_after:
                 try:
-                    retry_after_sleep = min(self.parse_retry_after(retry_after), self.max_backoff_wait)
+                    retry_after_sleep = min(
+                        self.parse_retry_after(retry_after), self.max_backoff_wait
+                    )
                     if retry_after_sleep > 0:
-                        return retry_after_sleep
+                        sleep_time = retry_after_sleep
                 except ValueError:
-                    logger.warning("Retry-After header is not a valid HTTP date: %s", retry_after)
+                    logger.warning(
+                        "Retry-After header is not a valid HTTP date: %s", retry_after
+                    )
 
         # Fall back to backoff strategy
-        return self.backoff_strategy() if self.attempts_made > 0 else 0.0
+        if sleep_time == 0.0:
+            sleep_time = self.backoff_strategy() if self.attempts_made > 0 else 0.0
+
+        # Cap by remaining total_timeout budget to bound cumulative sleep
+        if self.total_timeout is not None:
+            remaining = max(0.0, self.total_timeout - self.elapsed_sleep)
+            sleep_time = min(sleep_time, remaining)
+
+        return sleep_time
 
     def sleep(self, response: Union[httpx.Response, Exception]) -> None:
         """
@@ -224,9 +270,12 @@ class Retry:
         of the time requested. If that is not present, it will use an exponential backoff. By default,
         the backoff factor is 0 and this method will return immediately.
         """
-        time_to_sleep = self._calculate_sleep(response.headers if isinstance(response, httpx.Response) else {})
+        time_to_sleep = self._calculate_sleep(
+            response.headers if isinstance(response, httpx.Response) else {}
+        )
         logger.debug("sleep seconds=%s", time_to_sleep)
         time.sleep(time_to_sleep)
+        self.elapsed_sleep += time_to_sleep
 
     async def asleep(self, response: Union[httpx.Response, Exception]) -> None:
         """
@@ -236,13 +285,18 @@ class Retry:
         of the time requested. If that is not present, it will use an exponential backoff. By default,
         the backoff factor is 0 and this method will return immediately.
         """
-        time_to_sleep = self._calculate_sleep(response.headers if isinstance(response, httpx.Response) else {})
+        time_to_sleep = self._calculate_sleep(
+            response.headers if isinstance(response, httpx.Response) else {}
+        )
         logger.debug("asleep seconds=%s", time_to_sleep)
         await asyncio.sleep(time_to_sleep)
+        self.elapsed_sleep += time_to_sleep
 
     def increment(self) -> "Retry":
         """Return a new Retry instance with the attempt count incremented."""
-        logger.debug("increment retry=%s new_attempts_made=%s", self, self.attempts_made + 1)
+        logger.debug(
+            "increment retry=%s new_attempts_made=%s", self, self.attempts_made + 1
+        )
         return self.__class__(
             total=self.total,
             max_backoff_wait=self.max_backoff_wait,
@@ -253,6 +307,8 @@ class Retry:
             retry_on_exceptions=self.retryable_exceptions,
             backoff_jitter=self.backoff_jitter,
             attempts_made=self.attempts_made + 1,
+            total_timeout=self.total_timeout,
+            elapsed_sleep=self.elapsed_sleep,
         )
 
     def __repr__(self) -> str:

--- a/httpx_retries/retry.py
+++ b/httpx_retries/retry.py
@@ -106,8 +106,8 @@ class Retry:
         self.backoff_jitter = backoff_jitter
         self.attempts_made = attempts_made
 
-        self.allowed_methods = frozenset(
-            HTTPMethod(method.upper()) for method in (allowed_methods or self.RETRYABLE_METHODS)
+        self.allowed_methods: frozenset[str] = frozenset(
+            method.upper() for method in (allowed_methods or self.RETRYABLE_METHODS)
         )
         self.status_forcelist = frozenset((status_forcelist or self.RETRYABLE_STATUS_CODES))
         self.retryable_exceptions = (
@@ -116,7 +116,7 @@ class Retry:
 
     def is_retryable_method(self, method: str) -> bool:
         """Check if a method is retryable."""
-        return HTTPMethod(method.upper()) in self.allowed_methods
+        return method.upper() in self.allowed_methods
 
     def is_retryable_status_code(self, status_code: int) -> bool:
         """Check if a status code is retryable."""

--- a/httpx_retries/retry.py
+++ b/httpx_retries/retry.py
@@ -130,13 +130,9 @@ class Retry:
         self.allowed_methods: frozenset[str] = frozenset(
             method.upper() for method in (allowed_methods or self.RETRYABLE_METHODS)
         )
-        self.status_forcelist = frozenset(
-            (status_forcelist or self.RETRYABLE_STATUS_CODES)
-        )
+        self.status_forcelist = frozenset((status_forcelist or self.RETRYABLE_STATUS_CODES))
         self.retryable_exceptions = (
-            self.RETRYABLE_EXCEPTIONS
-            if retry_on_exceptions is None
-            else tuple(retry_on_exceptions)
+            self.RETRYABLE_EXCEPTIONS if retry_on_exceptions is None else tuple(retry_on_exceptions)
         )
 
     def is_retryable_method(self, method: str) -> bool:
@@ -194,9 +190,7 @@ class Retry:
             if parsed_date.tzinfo is None:
                 parsed_date = parsed_date.replace(tzinfo=datetime.timezone.utc)
 
-            diff = (
-                parsed_date - datetime.datetime.now(datetime.timezone.utc)
-            ).total_seconds()
+            diff = (parsed_date - datetime.datetime.now(datetime.timezone.utc)).total_seconds()
             return max(0.0, diff)
         except (TypeError, ValueError):
             raise ValueError(f"Invalid Retry-After header: {retry_after}")
@@ -231,9 +225,7 @@ class Retry:
 
         return min(backoff, self.max_backoff_wait)
 
-    def _calculate_sleep(
-        self, headers: Union[httpx.Headers, Mapping[str, str]]
-    ) -> float:
+    def _calculate_sleep(self, headers: Union[httpx.Headers, Mapping[str, str]]) -> float:
         """Calculate the sleep duration based on headers and backoff strategy."""
         sleep_time = 0.0
         # Check Retry-After header first if enabled
@@ -241,15 +233,11 @@ class Retry:
             retry_after = headers.get("Retry-After", "").strip()
             if retry_after:
                 try:
-                    retry_after_sleep = min(
-                        self.parse_retry_after(retry_after), self.max_backoff_wait
-                    )
+                    retry_after_sleep = min(self.parse_retry_after(retry_after), self.max_backoff_wait)
                     if retry_after_sleep > 0:
                         sleep_time = retry_after_sleep
                 except ValueError:
-                    logger.warning(
-                        "Retry-After header is not a valid HTTP date: %s", retry_after
-                    )
+                    logger.warning("Retry-After header is not a valid HTTP date: %s", retry_after)
 
         # Fall back to backoff strategy
         if sleep_time == 0.0:
@@ -270,9 +258,7 @@ class Retry:
         of the time requested. If that is not present, it will use an exponential backoff. By default,
         the backoff factor is 0 and this method will return immediately.
         """
-        time_to_sleep = self._calculate_sleep(
-            response.headers if isinstance(response, httpx.Response) else {}
-        )
+        time_to_sleep = self._calculate_sleep(response.headers if isinstance(response, httpx.Response) else {})
         logger.debug("sleep seconds=%s", time_to_sleep)
         time.sleep(time_to_sleep)
         self.elapsed_sleep += time_to_sleep
@@ -285,18 +271,14 @@ class Retry:
         of the time requested. If that is not present, it will use an exponential backoff. By default,
         the backoff factor is 0 and this method will return immediately.
         """
-        time_to_sleep = self._calculate_sleep(
-            response.headers if isinstance(response, httpx.Response) else {}
-        )
+        time_to_sleep = self._calculate_sleep(response.headers if isinstance(response, httpx.Response) else {})
         logger.debug("asleep seconds=%s", time_to_sleep)
         await asyncio.sleep(time_to_sleep)
         self.elapsed_sleep += time_to_sleep
 
     def increment(self) -> "Retry":
         """Return a new Retry instance with the attempt count incremented."""
-        logger.debug(
-            "increment retry=%s new_attempts_made=%s", self, self.attempts_made + 1
-        )
+        logger.debug("increment retry=%s new_attempts_made=%s", self, self.attempts_made + 1)
         return self.__class__(
             total=self.total,
             max_backoff_wait=self.max_backoff_wait,

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -434,3 +434,101 @@ def test_is_retry_custom_configuration() -> None:
     assert retry.is_retry("POST", 404, False) is True
     assert retry.is_retry("GET", 404, False) is False
     assert retry.is_retry("POST", 429, False) is False
+
+
+def test_total_timeout_default_is_none() -> None:
+    retry = Retry()
+    assert retry.total_timeout is None
+    assert retry.elapsed_sleep == 0.0
+
+
+def test_total_timeout_custom() -> None:
+    retry = Retry(total_timeout=30.0)
+    assert retry.total_timeout == 30.0
+
+
+def test_retry_validation_negative_total_timeout() -> None:
+    with pytest.raises(ValueError, match="total_timeout must be positive"):
+        Retry(total_timeout=-1)
+
+
+def test_retry_validation_zero_total_timeout() -> None:
+    with pytest.raises(ValueError, match="total_timeout must be positive"):
+        Retry(total_timeout=0)
+
+
+def test_retry_validation_negative_elapsed_sleep() -> None:
+    with pytest.raises(ValueError, match="elapsed_sleep must be non-negative"):
+        Retry(elapsed_sleep=-0.1)
+
+
+def test_calculate_sleep_capped_by_total_timeout() -> None:
+    retry = Retry(total_timeout=5)
+    headers = Headers({"Retry-After": "10"})
+    assert retry._calculate_sleep(headers) == 5.0
+
+
+def test_calculate_sleep_capped_by_remaining_total_timeout() -> None:
+    retry = Retry(total_timeout=10)
+    retry.elapsed_sleep = 7.0
+    headers = Headers({"Retry-After": "10"})
+    assert retry._calculate_sleep(headers) == 3.0
+
+
+def test_calculate_sleep_zero_when_total_timeout_exhausted() -> None:
+    retry = Retry(total_timeout=5)
+    retry.elapsed_sleep = 5.0
+    headers = Headers({"Retry-After": "10"})
+    assert retry._calculate_sleep(headers) == 0.0
+
+
+def test_calculate_sleep_no_cap_without_total_timeout() -> None:
+    retry = Retry()
+    headers = Headers({"Retry-After": "10"})
+    assert retry._calculate_sleep(headers) == 10.0
+
+
+def test_sleep_updates_elapsed_sleep(mock_sleep: MagicMock) -> None:
+    retry = Retry()
+    assert retry.elapsed_sleep == 0.0
+    response = Response(status_code=429, headers={"Retry-After": "5"})
+    retry.sleep(response)
+    assert retry.elapsed_sleep == 5.0
+    retry.sleep(response)
+    assert retry.elapsed_sleep == 10.0
+
+
+@pytest.mark.asyncio
+async def test_asleep_updates_elapsed_sleep(mock_asleep: AsyncMock) -> None:
+    retry = Retry()
+    assert retry.elapsed_sleep == 0.0
+    response = Response(status_code=429, headers={"Retry-After": "5"})
+    await retry.asleep(response)
+    assert retry.elapsed_sleep == 5.0
+    await retry.asleep(response)
+    assert retry.elapsed_sleep == 10.0
+
+
+def test_increment_preserves_total_timeout() -> None:
+    retry = Retry(total_timeout=30.0)
+    new_retry = retry.increment()
+    assert new_retry.total_timeout == 30.0
+
+
+def test_increment_preserves_elapsed_sleep() -> None:
+    retry = Retry(total_timeout=30.0)
+    retry.elapsed_sleep = 12.5
+    new_retry = retry.increment()
+    assert new_retry.elapsed_sleep == 12.5
+
+
+def test_is_exhausted_by_total_timeout() -> None:
+    retry = Retry(total=10, total_timeout=5)
+    retry.elapsed_sleep = 5.0
+    assert retry.is_exhausted() is True
+
+
+def test_is_exhausted_below_total_timeout() -> None:
+    retry = Retry(total=10, total_timeout=5)
+    retry.elapsed_sleep = 4.9
+    assert retry.is_exhausted() is False

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -77,6 +77,20 @@ def test_custom_retryable_methods_enum() -> None:
     assert retry.is_retryable_method("GET") is False
 
 
+def test_non_standard_method_not_retryable_by_default() -> None:
+    retry = Retry()
+    assert retry.is_retryable_method("PROPFIND") is False
+    assert retry.is_retryable_method("propfind") is False
+
+
+def test_non_standard_method_can_be_configured() -> None:
+    retry = Retry(allowed_methods=["PROPFIND", "GET"])
+    assert retry.is_retryable_method("PROPFIND") is True
+    assert retry.is_retryable_method("propfind") is True
+    assert retry.is_retryable_method("GET") is True
+    assert retry.is_retryable_method("POST") is False
+
+
 def test_custom_retry_status_codes() -> None:
     retry = Retry(status_forcelist=[500])
     assert retry.is_retryable_status_code(500) is True

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -161,6 +161,31 @@ def test_unretryable_method(mock_responses: MockResponse) -> None:
     assert mock_sleep.call_count == 0
 
 
+def test_non_standard_method_passes_through(mock_responses: MockResponse) -> None:
+    mock_sleep, status_code_sequences = mock_responses
+    status_code_sequences["https://example.com/dav"] = status_codes([(207, None)])
+    transport = RetryTransport()
+
+    with httpx.Client(transport=transport) as client:
+        response = client.request("PROPFIND", "https://example.com/dav")
+        assert response.status_code == 207
+
+    assert mock_sleep.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_async_non_standard_method_passes_through(mock_async_responses: AsyncMockResponse) -> None:
+    mock_asleep, status_code_sequences = mock_async_responses
+    status_code_sequences["https://example.com/dav"] = astatus_codes([(207, None)])
+    transport = RetryTransport()
+
+    async with httpx.AsyncClient(transport=transport) as client:
+        response = await client.request("PROPFIND", "https://example.com/dav")
+        assert response.status_code == 207
+
+    assert mock_asleep.call_count == 0
+
+
 def test_unretryable_exception(mock_responses: MockResponse) -> None:
     mock_sleep, _ = mock_responses
     transport = RetryTransport()

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -487,6 +487,37 @@ async def test_async_from_base_transport() -> None:
         assert response.status_code == 200
 
 
+def test_retry_after_capped_by_total_timeout(mock_responses: MockResponse) -> None:
+    mock_sleep, status_code_sequences = mock_responses
+    status_code_sequences["https://example.com/fail"] = status_codes([(429, "120")])
+    retry = Retry(total=10, total_timeout=10)
+    transport = RetryTransport(retry=retry)
+
+    with httpx.Client(transport=transport) as client:
+        response = client.get("https://example.com/fail")
+
+    assert response.status_code == 429
+    total_slept = sum(c.args[0] for c in mock_sleep.call_args_list)
+    assert total_slept <= 10
+    assert mock_sleep.call_count < 10
+
+
+@pytest.mark.asyncio
+async def test_async_retry_after_capped_by_total_timeout(mock_async_responses: AsyncMockResponse) -> None:
+    mock_asleep, status_code_sequences = mock_async_responses
+    status_code_sequences["https://example.com/fail"] = astatus_codes([(429, "120")])
+    retry = Retry(total=10, total_timeout=10)
+    transport = RetryTransport(retry=retry)
+
+    async with httpx.AsyncClient(transport=transport) as client:
+        response = await client.get("https://example.com/fail")
+
+    assert response.status_code == 429
+    total_slept = sum(c.args[0] for c in mock_asleep.call_args_list)
+    assert total_slept <= 10
+    assert mock_asleep.call_count < 10
+
+
 @pytest.mark.parametrize("status_code", Retry.RETRYABLE_STATUS_CODES)
 @pytest.mark.asyncio
 async def test_retry_operation_async_always_closes_response(status_code: int) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -300,7 +300,7 @@ wheels = [
 
 [[package]]
 name = "httpx-retries"
-version = "0.4.2"
+version = "0.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Implement the following security fixes:

  - Fixes #56 , where a custom HTTP method can raise a ValueError; this is untrusted input and should be ignored.
  - Fixes #57: Add total_timeout to Retry to cap cumulative sleep across attempts. Each sleep is capped by the remaining budget; is_exhausted() short-circuits the retry loop once the budget is consumed.
  Opt-in (None by default). 
  - Pin third-party GitHub Actions to commit SHAs in publish.yml and test-suite.yml (addresses #07): actions/checkout, actions/setup-python, astral-sh/setup-uv.
  - Restrict publish.yml trigger from tags: ["*"] to semver patterns so stray tags no longer trigger PyPI publish or docs deploy (addresses #08).
  - Document the per-attempt vs. cumulative sleep distinction in docs/behaviour.md.

