### PR TITLE
fix: log warning when Retry-After date has no timezone info

### DIFF
--- a/httpx_retries/retry.py
+++ b/httpx_retries/retry.py
@@ -188,6 +188,9 @@ class Retry:
         try:
             parsed_date = parsedate_to_datetime(retry_after)
             if parsed_date.tzinfo is None:
+                logger.warning(
+                    "Retry-After date has no timezone info, assuming UTC: %s", retry_after
+                )
                 parsed_date = parsed_date.replace(tzinfo=datetime.timezone.utc)
 
             diff = (parsed_date - datetime.datetime.now(datetime.timezone.utc)).total_seconds()

--- a/httpx_retries/retry.py
+++ b/httpx_retries/retry.py
@@ -188,9 +188,7 @@ class Retry:
         try:
             parsed_date = parsedate_to_datetime(retry_after)
             if parsed_date.tzinfo is None:
-                logger.warning(
-                    "Retry-After date has no timezone info, assuming UTC: %s", retry_after
-                )
+                logger.warning("Retry-After date has no timezone info, assuming UTC: %s", retry_after)
                 parsed_date = parsed_date.replace(tzinfo=datetime.timezone.utc)
 
             diff = (parsed_date - datetime.datetime.now(datetime.timezone.utc)).total_seconds()

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -151,6 +151,17 @@ def test_parse_retry_after_http_date_no_tz() -> None:
     assert 3 < result < 7
 
 
+def test_parse_retry_after_http_date_no_tz_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    import logging
+    retry = Retry()
+    future_date = (datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=5)).strftime(
+        "%a, %d %b %Y %H:%M:%S"
+    )
+    with caplog.at_level(logging.WARNING, logger="httpx_retries.retry"):
+        retry.parse_retry_after(future_date)
+    assert "assuming UTC" in caplog.text
+
+
 def test_calculate_sleep_with_retry_after_over_max() -> None:
     retry = Retry(max_backoff_wait=5)
     headers = Headers({"Retry-After": "10"})

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -153,6 +153,7 @@ def test_parse_retry_after_http_date_no_tz() -> None:
 
 def test_parse_retry_after_http_date_no_tz_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
     import logging
+
     retry = Retry()
     future_date = (datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=5)).strftime(
         "%a, %d %b %Y %H:%M:%S"


### PR DESCRIPTION
Fixes #58.
When parsedate_to_datetime returns a timezone-naive datetime, the code was silently assuming UTC. As suggested in the issue, this PR preserves that behaviour but adds a logger.warning so server bugs surface rather than being silently swallowed.
Changes:

httpx_retries/retry.py: added warning log when timezone is absent
tests/test_retry.py: added test_parse_retry_after_http_date_no_tz_logs_warning to assert the warning is emitted
